### PR TITLE
Fix gantt chart task persistence and enable inline editing

### DIFF
--- a/pages/backlog.html
+++ b/pages/backlog.html
@@ -232,7 +232,7 @@
                                 <th>Total Time (h)</th>
                                 <th>Total Cost (€)</th>
                                 <th>Color</th>
-                                <th class="text-center" style="width: 80px;">Delete</th>
+                                <th class="text-center" style="width: 120px;">Actions</th>
                             </tr>
                         </thead>
                         <tbody id="backlog-table-body">
@@ -593,6 +593,76 @@
                 width: 60px;
                 height: 30px;
             }
+        }
+
+        /* Inline editing styles */
+        .editable-cell {
+            position: relative;
+        }
+
+        .edit-input, .edit-select {
+            width: 100%;
+            padding: 4px 8px;
+            border: 1px solid var(--primary-blue);
+            border-radius: 4px;
+            font-size: 14px;
+            background: white;
+        }
+
+        .edit-input:focus, .edit-select:focus {
+            outline: none;
+            border-color: var(--primary-blue);
+            box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.2);
+        }
+
+        .action-buttons, .save-cancel-buttons {
+            display: flex;
+            gap: 4px;
+            justify-content: center;
+        }
+
+        .btn-edit, .btn-save, .btn-cancel, .btn-delete {
+            background: none;
+            border: none;
+            cursor: pointer;
+            padding: 4px;
+            border-radius: 4px;
+            font-size: 16px;
+            transition: all 0.2s ease;
+        }
+
+        .btn-edit:hover {
+            background: rgba(37, 99, 235, 0.1);
+        }
+
+        .btn-save:hover {
+            background: rgba(34, 197, 94, 0.1);
+        }
+
+        .btn-cancel:hover {
+            background: rgba(239, 68, 68, 0.1);
+        }
+
+        .btn-delete:hover {
+            background: rgba(239, 68, 68, 0.1);
+        }
+
+        tr.editing {
+            background: rgba(37, 99, 235, 0.05);
+        }
+
+        tr.editing td {
+            border-color: var(--primary-blue);
+        }
+
+        .edit-color-container {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .color-preview-edit {
+            border: 2px solid var(--border-color);
         }
     </style>
 </body>

--- a/scripts/storageService.js
+++ b/scripts/storageService.js
@@ -656,7 +656,7 @@ class StorageService {
             }
             
             // Additional validation: check if event has required properties
-            if (!event.startTime || !event.endTime) {
+            if (!event.startHour || !event.endHour) {
                 reason = `Event missing required time properties: ${event.taskTitle}`;
                 results.ghostTasksRemoved++;
                 results.details.push(reason);

--- a/test_gantt_fix.html
+++ b/test_gantt_fix.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Gantt Fix</title>
+</head>
+<body>
+    <h1>Testing Gantt Chart Data Integrity Fix</h1>
+    <div id="results"></div>
+
+    <script src="scripts/storageService.js"></script>
+    <script>
+        // Test the fix
+        function testGanttFix() {
+            const results = document.getElementById('results');
+            
+            // Create a test event with correct properties
+            const testEvent = {
+                id: 'test-event-1',
+                taskId: 'test-task-1',
+                taskTitle: 'Test Task',
+                machine: 'Test Machine',
+                date: '2025-01-01',
+                startHour: 8,
+                endHour: 10,
+                color: '#1a73e8',
+                duration: 2
+            };
+
+            // Add test data
+            const tasks = [{
+                id: 'test-task-1',
+                name: 'Test Task',
+                type: 'packaging'
+            }];
+
+            const machines = [{
+                name: 'Test Machine',
+                type: 'packaging',
+                live: true
+            }];
+
+            // Store test data
+            localStorage.setItem('backlogTasks', JSON.stringify(tasks));
+            localStorage.setItem('schedulerMachines', JSON.stringify(machines));
+            localStorage.setItem('scheduledEvents', JSON.stringify([testEvent]));
+
+            // Initialize storage service
+            window.storageService = new StorageService();
+
+            // Test the sync function
+            const syncResults = window.storageService.syncGanttChartData();
+            
+            results.innerHTML = `
+                <h2>Test Results:</h2>
+                <p><strong>Events removed:</strong> ${syncResults.orphanedEventsRemoved}</p>
+                <p><strong>Ghost tasks removed:</strong> ${syncResults.ghostTasksRemoved}</p>
+                <p><strong>Ghost machines removed:</strong> ${syncResults.ghostMachinesRemoved}</p>
+                <p><strong>Details:</strong></p>
+                <ul>
+                    ${syncResults.details.map(detail => `<li>${detail}</li>`).join('')}
+                </ul>
+                
+                <h3>Expected Result:</h3>
+                <p>Events removed should be 0, meaning the fix worked correctly.</p>
+            `;
+
+            // Clean up test data
+            localStorage.removeItem('backlogTasks');
+            localStorage.removeItem('schedulerMachines');
+            localStorage.removeItem('scheduledEvents');
+        }
+
+        // Run test when page loads
+        document.addEventListener('DOMContentLoaded', testGanttFix);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Implement inline editing for backlog tasks and fix Gantt chart data persistence bug.

The Gantt chart bug was caused by `storageService.js` incorrectly validating `event.startTime` and `event.endTime` properties for scheduled events, while the events were actually stored with `startHour` and `endHour`. This led to valid scheduled tasks being erroneously identified as "orphaned" and removed upon page refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-1890f7ed-d9f2-4aa3-856d-6749642f4509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1890f7ed-d9f2-4aa3-856d-6749642f4509">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>